### PR TITLE
Added Historical nodes and Batch account data requests

### DIFF
--- a/integration_test/infrastructure/account/AccountHttp.spec.ts
+++ b/integration_test/infrastructure/account/AccountHttp.spec.ts
@@ -326,14 +326,40 @@ describe("AccountHttp", () => {
   });
 
   it("should get historical account data", (done) => {
-    const accountHttp = new AccountHttp([{domain: TestVariables.ACCOUNT_HISTORICAL_DATA_NODE_DOMAIN}]);
-    accountHttp.getHistoricalAccountData(new Address("NALICELGU3IVY4DPJKHYLSSVYFFWYS5QPLYEZDJJ"), 17592, 17592, 1)
+    const accountHttp = new AccountHttp();
+    accountHttp.getHistoricalAccountData(new Address("TALICESKTW5TAN5GEOK4TQKD43AUGSDTHK7UIIAK"), 17592, 17592, 1)
       .subscribe((accountHistoryData) => {
         expect(accountHistoryData[0].address.plain()).to.not.be.null;
         expect(accountHistoryData[0].balance.balance).to.not.be.null;
         expect(accountHistoryData[0].balance.vestedBalance).to.not.be.null;
         expect(accountHistoryData[0].pageRank).to.not.be.null;
         expect(accountHistoryData[0].importance).to.not.be.null;
+        done();
+      });
+  });
+
+  it("should get batch account data", (done) => {
+    const accountHttp = new AccountHttp();
+    accountHttp.getBatchAccountData([new Address("TALICESKTW5TAN5GEOK4TQKD43AUGSDTHK7UIIAK")])
+      .subscribe((accountHistoryData) => {
+        expect(accountHistoryData[0].publicAccount.address.plain()).to.not.be.null;
+        expect(accountHistoryData[0].balance.balance).to.not.be.null;
+        expect(accountHistoryData[0].balance.vestedBalance).to.not.be.null;
+        expect(accountHistoryData[0].importance).to.not.be.null;
+        expect(accountHistoryData[0].harvestedBlocks).to.not.be.null;
+        done();
+      });
+  });
+
+  it("should get batch historical account data", (done) => {
+    const accountHttp = new AccountHttp();
+    accountHttp.getBatchHistoricalAccountData([new Address("TALICESKTW5TAN5GEOK4TQKD43AUGSDTHK7UIIAK")], 17592, 17592, 1)
+      .subscribe((accountHistoryData) => {
+        expect(accountHistoryData[0][0].address.plain()).to.not.be.null;
+        expect(accountHistoryData[0][0].balance.balance).to.not.be.null;
+        expect(accountHistoryData[0][0].balance.vestedBalance).to.not.be.null;
+        expect(accountHistoryData[0][0].pageRank).to.not.be.null;
+        expect(accountHistoryData[0][0].importance).to.not.be.null;
         done();
       });
   });

--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -448,19 +448,21 @@ export class AccountHttp extends HttpEndpoint {
    * @return Observable<AccountHistoricalInfo[][]>
    */
   public getBatchHistoricalAccountData(addresses: Address[], startHeight: number, endHeight: number, increment: number): Observable<AccountHistoricalInfo[][]> {
-    return Observable.of("/account/historical/get/batch")
-      .flatMap((url) => requestPromise.post({
+    return Observable.of("historical/get/batch")
+      .flatMap((url) => {
+        return requestPromise.post({
         uri: this.nextHistoricalNode() + url,
-        body: {
-          accounts: addresses.map((a) => {
-            return {account: a.plain()};
-          }),
-          startHeight: (startHeight),
-          endHeight: (endHeight),
-          incrementBy: increment,
-        },
-        json: true,
-      }))
+          body: {
+            accounts: addresses.map((a) => {
+              return {account: a.plain()};
+            }),
+            startHeight: (startHeight),
+            endHeight: (endHeight),
+            incrementBy: increment,
+          },
+          json: true,
+        });
+      })
       .retryWhen(this.replyWhenRequestError)
       .map((batchHistoricalAccountData) => {
         return batchHistoricalAccountData.data.map((historicalAccountData) => {
@@ -477,16 +479,19 @@ export class AccountHttp extends HttpEndpoint {
    * @return Observable<AccountHistoricalInfo[][]>
    */
   public getBatchAccountData(addresses: Address[]): Observable<AccountInfoWithMetaData[]> {
-    return Observable.of("/account/get/batch")
-      .flatMap((url) => requestPromise.post({
-        uri: this.nextNode() + url,
-        body: {
-          accounts: addresses.map((a) => {
-            return {account: a.plain()};
-          }),
-        },
-        json: true,
-      }))
+    return Observable.of("get/batch")
+      .flatMap((url) => {
+        const options = {
+          uri: this.nextNode() + url,
+          body: {
+            data: addresses.map((a) => {
+              return {account: a.plain()};
+            }),
+          },
+          json: true,
+        };
+        return requestPromise.post(options);
+      })
       .retryWhen(this.replyWhenRequestError)
       .map((batchAccountData) => {
         return batchAccountData.data.map((accountMetaDataPairDTO: AccountMetaDataPairDTO) => {

--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -476,7 +476,7 @@ export class AccountHttp extends HttpEndpoint {
   /**
    * Gets batch information for an array of accounts.
    * @param addresses - The addresses of the accounts as an array of addresses.
-   * @return Observable<AccountHistoricalInfo[][]>
+   * @return Observable<AccountInfoWithMetadata[]>
    */
   public getBatchAccountData(addresses: Address[]): Observable<AccountInfoWithMetaData[]> {
     return Observable.of("get/batch")

--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -430,11 +430,67 @@ export class AccountHttp extends HttpEndpoint {
    */
   public getHistoricalAccountData(address: Address, startHeight: number, endHeight: number, increment: number): Observable<AccountHistoricalInfo[]> {
     return Observable.of("historical/get?address=" + address.plain() + "&startHeight=" + startHeight + "&endHeight=" + endHeight + "&increment=" + increment)
-      .flatMap((url) => requestPromise.get(this.nextNode() + url, {json: true}))
+      .flatMap((url) => requestPromise.get(this.nextHistoricalNode() + url, {json: true}))
       .retryWhen(this.replyWhenRequestError)
       .map((historicalAccountData) => {
         return historicalAccountData.data.map((accountHistoricalDataViewModelDTO: AccountHistoricalDataViewModelDTO) => {
           return AccountHistoricalInfo.createFromAccountHistoricalDataViewModelDTO(accountHistoricalDataViewModelDTO);
+        });
+      });
+  }
+
+  /**
+   * Gets historical information for an array of accounts.
+   * @param addresses - The addresses of the accounts as an array of addresses.
+   * @param startHeight - The block height from which on the data should be supplied.
+   * @param endHeight - The block height up to which the data should be supplied. The end height must be greater than or equal to the start height.
+   * @param increment - The value by which the height is incremented between each data point. The value must be greater than 0. NIS can supply up to 1000 data points with one request. Requesting more than 1000 data points results in an error.
+   * @return Observable<AccountHistoricalInfo[][]>
+   */
+  public getBatchHistoricalAccountData(addresses: Address[], startHeight: number, endHeight: number, increment: number): Observable<AccountHistoricalInfo[][]> {
+    return Observable.of("/account/historical/get/batch")
+      .flatMap((url) => requestPromise.post({
+        uri: this.nextHistoricalNode() + url,
+        body: {
+          accounts: addresses.map((a) => {
+            return {account: a.plain()};
+          }),
+          startHeight: (startHeight),
+          endHeight: (endHeight),
+          incrementBy: increment,
+        },
+        json: true,
+      }))
+      .retryWhen(this.replyWhenRequestError)
+      .map((batchHistoricalAccountData) => {
+        return batchHistoricalAccountData.data.map((historicalAccountData) => {
+          return historicalAccountData.data.map((accountHistoricalDataViewModelDTO: AccountHistoricalDataViewModelDTO) => {
+            return AccountHistoricalInfo.createFromAccountHistoricalDataViewModelDTO(accountHistoricalDataViewModelDTO);
+          });
+        });
+      });
+  }
+
+  /**
+   * Gets batch information for an array of accounts.
+   * @param addresses - The addresses of the accounts as an array of addresses.
+   * @return Observable<AccountHistoricalInfo[][]>
+   */
+  public getBatchAccountData(addresses: Address[]): Observable<AccountInfoWithMetaData[]> {
+    return Observable.of("/account/get/batch")
+      .flatMap((url) => requestPromise.post({
+        uri: this.nextNode() + url,
+        body: {
+          accounts: addresses.map((a) => {
+            return {account: a.plain()};
+          }),
+        },
+        json: true,
+      }))
+      .retryWhen(this.replyWhenRequestError)
+      .map((batchAccountData) => {
+        return batchAccountData.data.map((accountMetaDataPairDTO: AccountMetaDataPairDTO) => {
+          return AccountInfoWithMetaData.createFromAccountMetaDataPairDTO(accountMetaDataPairDTO);
         });
       });
   }

--- a/test/infrastructure/HttpEndpoint.spec.ts
+++ b/test/infrastructure/HttpEndpoint.spec.ts
@@ -71,4 +71,20 @@ describe("HttpEndpoint", () => {
     expect(mockHttpEndpoint.nextNode()).to.contain("http://");
     NEMLibrary.reset();
   });
+
+  it("should have the mainnet historical node with protocol http", () => {
+    NEMLibrary.bootstrap(NetworkTypes.MAIN_NET);
+    const mockHttpEndpoint = new MockHttpEndpoint(undefined, "http");
+    expect(mockHttpEndpoint.nextHistoricalNode()).to.equal("http://88.99.192.82:7890/mock/");
+    expect(mockHttpEndpoint.nextHistoricalNode()).to.equal("http://88.99.192.82:7890/mock/");
+    NEMLibrary.reset();
+  });
+
+  it("should have the testnet historical node with protocol http", () => {
+    NEMLibrary.bootstrap(NetworkTypes.TEST_NET);
+    const mockHttpEndpoint = new MockHttpEndpoint(undefined, "http");
+    expect(mockHttpEndpoint.nextHistoricalNode()).to.equal("http://104.128.226.60:7890/mock/");
+    expect(mockHttpEndpoint.nextHistoricalNode()).to.equal("http://104.128.226.60:7890/mock/");
+    NEMLibrary.reset();
+  });
 });

--- a/test/infrastructure/account/AccountBatchHistoricalInfo.spec.ts
+++ b/test/infrastructure/account/AccountBatchHistoricalInfo.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 NEM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {expect} from "chai";
+import nock = require("nock");
+import {AccountHttp} from "../../../src/infrastructure/AccountHttp";
+import {Address} from "../../../src/models/account/Address";
+import {NetworkTypes} from "../../../src/models/node/NetworkTypes";
+import {NEMLibrary} from "../../../src/NEMLibrary";
+
+describe("AccountAllTransactionsPageable", () => {
+  let addresses: Address[];
+  let accountHttp: AccountHttp;
+
+  before(() => {
+    NEMLibrary.bootstrap(NetworkTypes.TEST_NET);
+    addresses = [new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Address("TALIC37D2B7KRFHGXRJAQO67YWOUWWA36OU46HSG")];
+    accountHttp = new AccountHttp();
+    nock("http://104.128.226.60:7890")
+        .post("/account/historical/get/batch", {
+            accounts: [
+                { account: "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C" },
+                { account: "TALIC37D2B7KRFHGXRJAQO67YWOUWWA36OU46HSG" }
+            ],
+            startHeight: 100000,
+            endHeight: 100001,
+            incrementBy: 1,
+        })
+      .once()
+      .replyWithFile(200, __dirname + "/responses/account_historical_batch.json");
+  });
+
+  after(() => {
+    NEMLibrary.reset();
+    nock.cleanAll();
+  });
+
+  it("should receive the historical info", (done) => {
+    accountHttp.getBatchHistoricalAccountData(addresses, 100000, 100001, 1)
+      .subscribe(
+        (x) => {
+          expect(x).to.have.length(2);
+          expect(x[0]).to.have.length(2);
+          expect(x[0][0].address.plain()).to.equal("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C");
+          done();
+        },
+      );
+  });
+});

--- a/test/infrastructure/account/AccountBatchInfo.spec.ts
+++ b/test/infrastructure/account/AccountBatchInfo.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 NEM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {expect} from "chai";
+import nock = require("nock");
+import {AccountHttp} from "../../../src/infrastructure/AccountHttp";
+import {Address} from "../../../src/models/account/Address";
+import {NetworkTypes} from "../../../src/models/node/NetworkTypes";
+import {NEMLibrary} from "../../../src/NEMLibrary";
+
+describe("AccountAllTransactionsPageable", () => {
+  let addresses: Address[];
+  let accountHttp: AccountHttp;
+
+  before(() => {
+    NEMLibrary.bootstrap(NetworkTypes.MAIN_NET);
+    const addressStrings = [
+        "NA2PDM4VPUGA37RYVPGTD6H7G7A2S6HTFRQUI55S",
+        "NBRUHCUQNNUUZEDC7HPE2NLXQ37WNZ76QWJAYR7X",
+        "NBUB64DLCEX55BEMDKICVCS36SAZG4XEI4M2B5IT",
+        "NBX3XORYMEBIMHVWURWPPYUTR4JHGN4ON7OHEBRG",
+        "NC7DTK6KIVE3PIOWHDCJHRATDAHBBP6S2HMRYN66",
+        "NCIELL3C776X5JM6VVJTRWBM73KRKF2BJM2DG4GO",
+        "NCVWYEJQR62AUWF7RQLICCRDZEH2XKJM7X4AJ5WS",
+        "ND7YZKRDJAPEFUYOMDA4LT2PCCNL3J7RZOX4YPQO",
+        "NDIBC7SQQIPVFIR2FYSZOWCHZ2W4FPTXOA56YFYU",
+        "NDIQO2RH64ZRKJHVYBUZLWKAUDDXNDQ77OI4MVS2",
+    ];
+    addresses = addressStrings.map((s) => new Address(s));
+    accountHttp = new AccountHttp();
+    nock("http://88.99.192.82:7890")
+        .post("/account/get/batch", {
+            data: [
+                { account: "NA2PDM4VPUGA37RYVPGTD6H7G7A2S6HTFRQUI55S" },
+                { account: "NBRUHCUQNNUUZEDC7HPE2NLXQ37WNZ76QWJAYR7X" },
+                { account: "NBUB64DLCEX55BEMDKICVCS36SAZG4XEI4M2B5IT" },
+                { account: "NBX3XORYMEBIMHVWURWPPYUTR4JHGN4ON7OHEBRG" },
+                { account: "NC7DTK6KIVE3PIOWHDCJHRATDAHBBP6S2HMRYN66" },
+                { account: "NCIELL3C776X5JM6VVJTRWBM73KRKF2BJM2DG4GO" },
+                { account: "NCVWYEJQR62AUWF7RQLICCRDZEH2XKJM7X4AJ5WS" },
+                { account: "ND7YZKRDJAPEFUYOMDA4LT2PCCNL3J7RZOX4YPQO" },
+                { account: "NDIBC7SQQIPVFIR2FYSZOWCHZ2W4FPTXOA56YFYU" },
+                { account: "NDIQO2RH64ZRKJHVYBUZLWKAUDDXNDQ77OI4MVS2" },
+            ],
+        })
+      .once()
+      .replyWithFile(200, __dirname + "/responses/account_batch_info.json");
+  });
+
+  after(() => {
+    NEMLibrary.reset();
+    nock.cleanAll();
+  });
+
+  it("should receive the account info", (done) => {
+    accountHttp.getBatchAccountData(addresses)
+      .subscribe(
+        (x) => {
+          expect(x).to.have.length(addresses.length);
+          expect(x[0].publicAccount.address.plain()).to.equal("NA2PDM4VPUGA37RYVPGTD6H7G7A2S6HTFRQUI55S");
+          done();
+        },
+      );
+  });
+});

--- a/test/infrastructure/account/responses/account_batch_info.json
+++ b/test/infrastructure/account/responses/account_batch_info.json
@@ -1,0 +1,184 @@
+{
+    "data": [
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NA2PDM4VPUGA37RYVPGTD6H7G7A2S6HTFRQUI55S",
+                "harvestedBlocks": 0,
+                "balance": 4091422463,
+                "importance": 0.000019872968254351248,
+                "vestedBalance": 4091422463,
+                "publicKey": "70c0e0eccc4c81a3bc87c744002622a87a8ca84f58c4f61587af20d41f711367",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "INACTIVE"
+            },
+            "account": {
+                "address": "NBRUHCUQNNUUZEDC7HPE2NLXQ37WNZ76QWJAYR7X",
+                "harvestedBlocks": 0,
+                "balance": 0,
+                "importance": 0,
+                "vestedBalance": 0,
+                "publicKey": "f7db90424f73bf2c742c1af9aab0fe65937ccf00b2cb8225f72b173925821a43",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NBUB64DLCEX55BEMDKICVCS36SAZG4XEI4M2B5IT",
+                "harvestedBlocks": 23,
+                "balance": 90297706356,
+                "importance": 0.000017502734680741725,
+                "vestedBalance": 90296133541,
+                "publicKey": "7ac994078bf2f09a425dd6ad37adb75b5cead0fc8266c927fb66033a23ff2d26",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NBX3XORYMEBIMHVWURWPPYUTR4JHGN4ON7OHEBRG",
+                "harvestedBlocks": 4,
+                "balance": 10117427962,
+                "importance": 0.000009563441234868578,
+                "vestedBalance": 10100414054,
+                "publicKey": "04b2b7affab590a186a82df9f7b114d76de26750486022cea3f111c7aea962a3",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NC7DTK6KIVE3PIOWHDCJHRATDAHBBP6S2HMRYN66",
+                "harvestedBlocks": 1,
+                "balance": 27208661559,
+                "importance": 0.000009430335612549722,
+                "vestedBalance": 15975968432,
+                "publicKey": "2c154980d6b203a943f21717a2d58daf035d47969cdfa78cf117ce158399f861",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NCIELL3C776X5JM6VVJTRWBM73KRKF2BJM2DG4GO",
+                "harvestedBlocks": 0,
+                "balance": 10498500000,
+                "importance": 0,
+                "vestedBalance": 5477099996,
+                "publicKey": "2e153174f64c83e43d00f013cbe7db8ba61053e8adfb691106d529eac4530132",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NCVWYEJQR62AUWF7RQLICCRDZEH2XKJM7X4AJ5WS",
+                "harvestedBlocks": 0,
+                "balance": 14944995148,
+                "importance": 0.000009895540465098586,
+                "vestedBalance": 12701831556,
+                "publicKey": "49ed28cf0ed9be89c00a9633693fc1ee2a4d2b30acfc3e9da9cda5d57a5e8e15",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "ND7YZKRDJAPEFUYOMDA4LT2PCCNL3J7RZOX4YPQO",
+                "harvestedBlocks": 40,
+                "balance": 67153138814,
+                "importance": 0.000016983227715541027,
+                "vestedBalance": 64508092840,
+                "publicKey": "336424acb2b7d12f440a3acb0cac5f94ddd7fa8a86d8b5a174931002aab30d3c",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NDIBC7SQQIPVFIR2FYSZOWCHZ2W4FPTXOA56YFYU",
+                "harvestedBlocks": 44,
+                "balance": 500161854176,
+                "importance": 0.00005805718301683381,
+                "vestedBalance": 499976892322,
+                "publicKey": "82f3392fec552651c143a92f08bd48b6da9496eb5720b62cb4e1af13c9aa180e",
+                "label": null,
+                "multisigInfo": {}
+            }
+        },
+        {
+            "meta": {
+                "cosignatories": [],
+                "cosignatoryOf": [],
+                "status": "LOCKED",
+                "remoteStatus": "ACTIVE"
+            },
+            "account": {
+                "address": "NDIQO2RH64ZRKJHVYBUZLWKAUDDXNDQ77OI4MVS2",
+                "harvestedBlocks": 5,
+                "balance": 11813911621,
+                "importance": 0.00000973372654741825,
+                "vestedBalance": 11813666694,
+                "publicKey": "11cc90d54904306a47c2c4e4b123545838802ece5abba13533f83cb7296f2a55",
+                "label": null,
+                "multisigInfo": {}
+            }
+        }
+    ]
+}

--- a/test/infrastructure/account/responses/account_historical_batch.json
+++ b/test/infrastructure/account/responses/account_historical_batch.json
@@ -1,0 +1,48 @@
+{
+    "data": [
+        {
+            "data": [
+                {
+                    "pageRank": 0.0035903320547790232,
+                    "address": "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C",
+                    "balance": 50386727995377,
+                    "importance": 0.0059685675660915375,
+                    "vestedBalance": 50382877508084,
+                    "unvestedBalance": 3850487293,
+                    "height": 100000
+                },
+                {
+                    "pageRank": 0.0035903320547790232,
+                    "address": "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C",
+                    "balance": 50386727995377,
+                    "importance": 0.0059685675660915375,
+                    "vestedBalance": 50382877508084,
+                    "unvestedBalance": 3850487293,
+                    "height": 100001
+                }
+            ]
+        },
+        {
+            "data": [
+                {
+                    "pageRank": 0.0035903320547790232,
+                    "address": "TALIC37D2B7KRFHGXRJAQO67YWOUWWA36OU46HSG",
+                    "balance": 50203823850265,
+                    "importance": 0.005948444666726026,
+                    "vestedBalance": 50200067389240,
+                    "unvestedBalance": 3756461025,
+                    "height": 100000
+                },
+                {
+                    "pageRank": 0.0035903320547790232,
+                    "address": "TALIC37D2B7KRFHGXRJAQO67YWOUWWA36OU46HSG",
+                    "balance": 50203823850265,
+                    "importance": 0.005948444666726026,
+                    "vestedBalance": 50200067389240,
+                    "unvestedBalance": 3756461025,
+                    "height": 100001
+                }
+            ]
+        }
+    ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,8 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+        "max-line-length": false
+    },
     "rulesDirectory": []
 }


### PR DESCRIPTION
I added historical nodes both for testnet and for mainnet that support historical account data calls. This way you don't have to try all the ones that don't have the option activated. Right now there is one node for each network, please add more if you know they support this option.

I also added two new calls for accountHttp:
- getBatchAccountData: gets account information for a list of accounts in the current block
- getBatchHistoricalAccountData: the same call but for historical data in a certain block (or interval of blocks)

This two calls are very important for the voting system since they allow to get importance scores of a lot of users quickly without triggering the spam protection, both for ongoing polls and for finished ones.