### PR TITLE
Add Mijin support

### DIFF
--- a/src/infrastructure/HttpEndpoint.ts
+++ b/src/infrastructure/HttpEndpoint.ts
@@ -49,8 +49,7 @@ export abstract class HttpEndpoint {
           port: _.port ? _.port : 7890,
         };
       });
-    }
-    else if (NEMLibrary.getNetworkType() == NetworkTypes.TEST_NET) {
+    } else if (NEMLibrary.getNetworkType() == NetworkTypes.TEST_NET) {
       this.nodes = [
         {protocol: "http", domain: "bigalice2.nem.ninja", port: 7890},
         {protocol: "http", domain: "192.3.61.243", port: 7890},

--- a/src/models/account/Account.ts
+++ b/src/models/account/Account.ts
@@ -102,6 +102,8 @@ export class Account extends PublicAccount {
       network = nemSdk.default.model.network.data.mainnet.id;
     } else if (NEMLibrary.getNetworkType() == NetworkTypes.TEST_NET) {
       network = nemSdk.default.model.network.data.testnet.id;
+    } else if (NEMLibrary.getNetworkType() == NetworkTypes.MIJIN_NET){
+      network = nemSdk.default.model.network.data.mijin.id;
     }
     const keyPair: any = nemSdk.default.crypto.keyPair.create(nemSdk.default.utils.helpers.fixPrivateKey(privateKey));
     const publicKey: string = keyPair.publicKey.toString();

--- a/src/models/account/Address.ts
+++ b/src/models/account/Address.ts
@@ -37,6 +37,8 @@ export class Address {
       this.networkType = NetworkTypes.TEST_NET;
     } else if (this.value.charAt(0) == "N") {
       this.networkType = NetworkTypes.MAIN_NET;
+    } else if (this.value.charAt(0) == "M") {
+      this.networkType = NetworkTypes.MIJIN_NET;
     } else {
       throw new Error("NetworkType invalid");
     }
@@ -63,7 +65,13 @@ export class Address {
    * @returns {number}
    */
   public network(): NetworkTypes {
-    return this.value.charAt(0) == "T" ? NetworkTypes.TEST_NET : NetworkTypes.MAIN_NET;
+    if (this.value.charAt(0) == "T") {
+      return NetworkTypes.TEST_NET;
+    } else if (this.value.charAt(0) == "N") {
+      return NetworkTypes.MAIN_NET;
+    } else {
+      return NetworkTypes.MIJIN_NET;
+    }
   }
 
   public equals(otherAddress: Address) {

--- a/src/models/account/PublicAccount.ts
+++ b/src/models/account/PublicAccount.ts
@@ -67,6 +67,8 @@ export class PublicAccount {
       network = nemSdk.default.model.network.data.mainnet.id;
     } else if (NEMLibrary.getNetworkType() == NetworkTypes.TEST_NET) {
       network = nemSdk.default.model.network.data.testnet.id;
+    } else if (NEMLibrary.getNetworkType() == NetworkTypes.MIJIN_NET){
+      network = nemSdk.default.model.network.data.mijin.id;
     }
     const address: string = nemSdk.default.model.address.toAddress(publicKey, network);
     return new PublicAccount(new Address(address), publicKey);

--- a/src/models/node/NetworkTypes.ts
+++ b/src/models/node/NetworkTypes.ts
@@ -36,4 +36,10 @@ export enum NetworkTypes {
    */
   TEST_NET = 0x98,
 
+  /**
+   * mijin net network
+   * @type {number}
+   */
+  MIJIN_NET = 0x60,
+
 }

--- a/src/models/transaction/Transaction.ts
+++ b/src/models/transaction/Transaction.ts
@@ -143,6 +143,9 @@ export abstract class Transaction {
     } else if (networkType == NetworkTypes.TEST_NET) {
       this.networkVersion = 0x98000000 | this.version;
       return;
+    } else if (networkType == NetworkTypes.MIJIN_NET) {
+      this.networkVersion = 0x60000000 | this.version;
+      return;
     }
     throw new Error("Unsupported Network Type " + networkType);
   }

--- a/src/models/wallet/SimpleWallet.ts
+++ b/src/models/wallet/SimpleWallet.ts
@@ -152,10 +152,17 @@ export class SimpleWallet extends Wallet {
     const wallet = JSON.parse(Base64.decode(wlt));
     // TODO: Check the encrypted and iv fields, if they aren't null, it's a simple wallet
     const account = wallet.accounts[0];
-    const network = account.network;
+    let network;
+    if (account.network < 0) {
+      network = NetworkTypes.TEST_NET;
+    } else if (account.network == 104) {
+      network = NetworkTypes.MAIN_NET;
+    } else {
+      network = NetworkTypes.MIJIN_NET;
+    }
     return new SimpleWallet(
       wallet.name,
-      network < 0 ? NetworkTypes.TEST_NET : NetworkTypes.MAIN_NET,
+      network,
       new Address(account.address),
       LocalDateTime.now(),
       new EncryptedPrivateKey(account.encrypted, account.iv)

--- a/src/models/wallet/Wallet.ts
+++ b/src/models/wallet/Wallet.ts
@@ -96,7 +96,13 @@ export abstract class Wallet {
    * @internal
    */
   public static networkTypesSDKAdapter(network: NetworkTypes): number {
-    return network == NetworkTypes.TEST_NET ? -104 : network;
+    if (network == NetworkTypes.MAIN_NET) {
+      return 104;
+    } else if (network == NetworkTypes.TEST_NET) {
+      return -104;
+    } else {
+      return 96;
+    }
   }
 
   /**


### PR DESCRIPTION
added mijin support with the following notes:

- `HttpEndpoints` and `Listner` class both needs mijin endpoints and we know that there is no specefic endpoints for mijin
- `MosaicDefinitionCreationTransaction` and `ProvisionNamespaceTransaction` class both needs sink address... not sure what are those for mijin
- `QRService` class has a type parameter 1 or 2 for both nets but not sure what would be the type for mijin