### PR TITLE
Closes #39 Mosaic properties transferable and supplyMutable are swapped

### DIFF
--- a/src/models/mosaic/MosaicDefinition.ts
+++ b/src/models/mosaic/MosaicDefinition.ts
@@ -227,8 +227,8 @@ export class MosaicProperties {
     return new MosaicProperties(
       Number(mosaicProperties[0].value),
       Number(mosaicProperties[1].value),
-      (mosaicProperties[2].value == "true"),
       (mosaicProperties[3].value == "true"),
+      (mosaicProperties[2].value == "true"),
     );
   }
 }


### PR DESCRIPTION
:warning: Can't run test suite.

Running `npm test`:

 `src/infrastructure/Pageable.ts(32,14): error TS2415: Class 'Pageable<T>' incorrectly extends base class 'Subject<T>'.`.

Please, test and review the pull-request before merging.