### PR TITLE
Add hex message support

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -50,6 +50,7 @@ export * from "./models/transaction/ImportanceTransferTransaction";
 export * from "./models/transaction/Message";
 export * from "./models/transaction/PlainMessage";
 export * from "./models/transaction/EncryptedMessage";
+export * from "./models/transaction/HexMessage";
 export * from "./models/transaction/MosaicDefinitionCreationTransaction";
 export * from "./models/transaction/MosaicSupplyChangeTransaction";
 export * from "./models/transaction/MultisigAggregateModificationTransaction";

--- a/src/models/transaction/HexMessage.ts
+++ b/src/models/transaction/HexMessage.ts
@@ -1,0 +1,40 @@
+import { Message } from "./Message";
+import { MessageDTO } from "../../infrastructure/transaction/Message";
+
+export class HexMessage extends Message {
+
+  /**
+   * @internal
+   * @param payload 
+   */
+  constructor(payload: string) {
+    super(payload);
+  }
+
+  /**
+   * Create new constructor
+   * @param message 
+   */
+  public static create(message: string) {
+    let msg = "fe" + message;
+    return new HexMessage(msg);
+  }
+
+  public isEncrypted(): boolean {
+    return false;
+  }
+
+  public isPlain(): boolean {
+    return true;
+  }
+
+  /**
+   * @internal
+   */
+  public toDTO(): MessageDTO {
+    return {
+      payload: this.payload,
+      type: 1,
+    } as MessageDTO;
+  }
+}

--- a/src/models/transaction/Message.ts
+++ b/src/models/transaction/Message.ts
@@ -46,6 +46,10 @@ export abstract class Message {
 
   public abstract isPlain(): boolean;
 
+  public isHexMessage(): boolean {
+    return this.isPlain() && this.payload.indexOf("fe") === 0;
+  }
+
   /**
    * @internal
    * @param message

--- a/test/models/transaction/Message.spec.ts
+++ b/test/models/transaction/Message.spec.ts
@@ -24,6 +24,7 @@
 
 import {expect} from "chai";
 import {Message} from "../../../src/models/transaction/Message";
+import { PlainMessage, HexMessage } from "../../../src/models";
 
 describe("Message", () => {
 
@@ -36,5 +37,15 @@ describe("Message", () => {
     const message = Message.decodeHex("74657374206d657373616765");
     expect(message).to.be.equal("test message");
   });
+
+  it("should it is not hex message", () => {
+    const message = PlainMessage.create("test message");
+    expect(message.isHexMessage()).to.be.false;
+  })
+
+  it("should it is hex message", () => {
+    const message = HexMessage.create("4e54590385412c4b934ee82d10e4d937b37284511c417f14d2cd81f01fb10583479873b0");
+    expect(message.isHexMessage()).to.be.true;
+  })
 
 });


### PR DESCRIPTION
added support to send hex message when sending transaction with the following notes.

* `HexMessage` can create hex type message.
 `message.isHexMessage` can check whether message is hex message.
