### PR TITLE
Fix getFromAddress

### DIFF
--- a/src/models/account/AccountInfo.ts
+++ b/src/models/account/AccountInfo.ts
@@ -95,7 +95,9 @@ export class AccountInfo {
               minCosignatories?: number) {
     this.balance = new Balance(balance, vestedBalance);
     this.importance = importance;
-    this.publicAccount = PublicAccount.createWithPublicKey(publicKey);
+    if (publicKey != null) {
+      this.publicAccount = PublicAccount.createWithPublicKey(publicKey);
+    }
     this.harvestedBlocks = harvestedBlocks;
     this.cosignatoriesCount = cosignatoriesCount;
     this.minCosignatories = minCosignatories;


### PR DESCRIPTION
I fix `getFromAddress` can get account info without public key.

Current ver, if there is no public key, `getFromAddress` failed.
The following log is when it fails.

```
Error: Not a valid public key
    at Function.createWithPublicKey (/node_modules/nem-library/src/models/account/PublicAccount.ts:63:13)
    at new AccountInfo (/node_modules/nem-library/src/models/account/AccountInfo.ts:98:40)
...
```

NIS API cat get account info when lacked public key.

http://192.3.61.243:7890/account/get?address=TADGMJICAFHQXQLO57ANQYQTOKWKPRNXQX3LOUXQ

So, I thought `getFromAddress` should get account info without public key.